### PR TITLE
Recap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store*
 .env
 node_modules
-
+.hubot_history

--- a/scripts/recap.coffee
+++ b/scripts/recap.coffee
@@ -8,23 +8,23 @@
 #   None
 #
 # Commands:
-#   mbot reset recap - resets the recap for this room
-#   mbot add recap <text> - adds <text> to the recap.
-#   mbot recap - prints the recap for this room.  
-#   mbot recap <room> - prints the recap for a given room.
+#   mbot recap reset - resets the recap for this channel
+#   mbot recap add <text> - adds <text> to the recap.
+#   mbot recap me - prints the recap for this channel.  
+#   mbot recap me #<channel> - prints the recap for a given channel.
 #
 # Author:
 #   Yaakov
 
 module.exports = (robot) ->
-  robot.respond /reset recap/i, (response) ->
+  robot.respond /recap reset/i, (response) ->
     # clean out the recap for this channel
-    robot.brain.set("recap_#{response.envelope.room}", null)
+    robot.brain.set("recap_##{response.envelope.room}", null)
     response.send("erased recap data for ##{response.envelope.room}")
 
-  robot.respond /add recap (.*)/i, (response) ->
+  robot.respond /recap add(.*)$/i, (response) ->
     recap = response.match[1].trim()
-    prev_recap = robot.brain.get("recap_#{response.envelope.room}") or ""
+    prev_recap = robot.brain.get("recap_##{response.envelope.room}") or ""
 
     # set up a nice, detailed timestamp 
     date_object = new Date
@@ -35,18 +35,18 @@ module.exports = (robot) ->
 
     # tack on the existing recap to maintain history
     recap = "#{prev_recap}\n#{recap}" 
-    robot.brain.set("recap_#{response.envelope.room}", recap)
-    response.send("set recap for #{response.envelope.room}")
+    robot.brain.set("recap_##{response.envelope.room}", recap)
+    response.send("set recap for ##{response.envelope.room}")
 
-  robot.respond /recap(.*)$/i, (response) ->
+  robot.respond /recap me(.*)$/i, (response) ->
     # default the recap channel to be the current channel
-    if response.match[1].trim()
+    if response.match[1] and response.match[1].trim()
       recap_target = response.match[1].trim()
     else
-      recap_target = response.envelope.room
+      recap_target = "##{response.envelope.room}"
 
     recap = robot.brain.get("recap_#{recap_target}")
     if recap is null
-      response.send("I don't have a recap for ##{recap_target}")
+      response.send("I don't have a recap for #{recap_target}")
     else
       response.send(recap)

--- a/scripts/recap.coffee
+++ b/scripts/recap.coffee
@@ -1,0 +1,52 @@
+# Description:
+#   Allows users to add recap data on a per-room basis to help people catch up on ongoing issues
+#
+# Dependencies:
+#   None
+#
+# Configuration:
+#   None
+#
+# Commands:
+#   mbot reset recap - resets the recap for this room
+#   mbot add recap <text> - adds <text> to the recap.
+#   mbot recap - prints the recap for this room.  
+#   mbot recap <room> - prints the recap for a given room.
+#
+# Author:
+#   Yaakov
+
+module.exports = (robot) ->
+  robot.respond /reset recap/i, (response) ->
+    # clean out the recap for this channel
+    robot.brain.set("recap_#{response.envelope.room}", null)
+    response.send("erased recap data for ##{response.envelope.room}")
+
+  robot.respond /add recap (.*)/i, (response) ->
+    recap = response.match[1].trim()
+    prev_recap = robot.brain.get("recap_#{response.envelope.room}") or ""
+
+    # set up a nice, detailed timestamp 
+    date_object = new Date
+    timestamp = "#{date_object.getMonth() + 1}-#{date_object.getDate()} #{date_object.getHours()}:#{date_object.getMinutes()}"
+
+    # stitch it all together 
+    recap = "#{response.message.user.name} [#{timestamp}] #{recap}"
+
+    # tack on the existing recap to maintain history
+    recap = "#{prev_recap}\n#{recap}" 
+    robot.brain.set("recap_#{response.envelope.room}", recap)
+    response.send("set recap for #{response.envelope.room}")
+
+  robot.respond /recap(.*)$/i, (response) ->
+    # default the recap channel to be the current channel
+    if response.match[1].trim()
+      recap_target = response.match[1].trim()
+    else
+      recap_target = response.envelope.room
+
+    recap = robot.brain.get("recap_#{recap_target}")
+    if recap is null
+      response.send("I don't have a recap for ##{recap_target}")
+    else
+      response.send(recap)


### PR DESCRIPTION
The recap functionality works as follows:

Any user can add to the recap by running "recap add".  The text they add will have the user's username and the current date/time prepended to it for readability.

Any user can run "recap reset" to clear the recap.

Any user can run "recap" to print the recap for that channel

Any user can run "recap [channel]" to print the recap for a given channel.  That lets people get the recap from a DM.

Examples:

```
mbot> mbot add recap test message
mbot> set recap for Shell
mbot> mbot recap
mbot> 
Shell [8-28 16:45] test message
mbot recap shell
mbot> I don't have a recap for #shell
mbot> mbot recap Shell
mbot> 
Shell [8-28 16:45] test message
mbot reset recap
mbot> erased recap data for #Shell
```

I also added .hubot_history to the .gitignore because my understanding is that we'd never add that to source control, so it's clutter.
