### PR TITLE
Tweaking the regex to match slightly more intelliigently.

### DIFF
--- a/scripts/karma.coffee
+++ b/scripts/karma.coffee
@@ -18,14 +18,10 @@ module.exports = (robot) ->
     doKarma(targetToken, response)
 
   # this regex is for matching persons, but only at the beginning of a line
-  # and it will ignore the user karma if it's got more than one space.
   robot.hear /^([\w\s]+?)(\+\+|--).*$/, (response) ->
     thisUser = response.message.user
     targetToken = response.match[1].trim()
     return if not targetToken
-    # if there's more than just two words in that target token, give up.
-    # this means it'll only match "david kowis" not "here's the thing --"
-    return if targetToken.split(" ").length > 2
     doKarma(targetToken, response)
 
 
@@ -46,6 +42,10 @@ module.exports = (robot) ->
     response.send msg
 
   doKarma = (targetToken, response) ->
+    # if there's more than just two words in that target token, give up.
+    # this means it'll only match "david kowis" not "here's the thing --"
+    # regardless of if @ was used or not
+    return if targetToken.split(" ").length > 2
     targetUser = userForToken targetToken, response
     return if not targetUser
     return response.send "Hey, you can't give yourself karma!" if thisUser is targetUser

--- a/scripts/karma.coffee
+++ b/scripts/karma.coffee
@@ -10,7 +10,7 @@
 
 module.exports = (robot) ->
 
-  robot.hear /^@?(.*?)(\+\+|--).*?$/, (response) ->
+  robot.hear /@(.*?)(\+\+|--).*?$/, (response) ->
     thisUser = response.message.user
     targetToken = response.match[1].replace(/.*@/, '').trim()
     return if not targetToken

--- a/scripts/karma.coffee
+++ b/scripts/karma.coffee
@@ -18,7 +18,7 @@ module.exports = (robot) ->
     doKarma(targetToken, response)
 
   # this regex is for matching persons, but only at the beginning of a line
-  robot.hear /^([\w\s]+?)(\+\+|--).*$/, (response) ->
+  robot.hear /^([\w\s\.]+?)(\+\+|--).*$/, (response) ->
     thisUser = response.message.user
     targetToken = response.match[1].trim()
     return if not targetToken


### PR DESCRIPTION
I've tweaked the regex to be a little less grabby

There's now two paths to deliver karma. The first path requires using an `@`, and will pick up in the middle of sentences.

![image](https://user-images.githubusercontent.com/28048/113320769-83fe3b80-92d8-11eb-92e1-597761b69e65.png)

The second path, will ignore lines with @, and only measures from the start of the line. As well, it's got logic that ignores lines with more than one space in the user name.

![image](https://user-images.githubusercontent.com/28048/113320720-6f21a800-92d8-11eb-9b9d-62cf2d36e866.png)

