### PR TITLE
Target token assignment algorithm 

### DIFF
--- a/scripts/karma.coffee
+++ b/scripts/karma.coffee
@@ -12,8 +12,18 @@ module.exports = (robot) ->
 
   robot.hear /^@?(.*?)(\+\+|--).*?$/, (response) ->
     thisUser = response.message.user
-    targetToken = response.match[1].replace(/.*@/, '').trim()
+
+    if (response.match[0].indexOf('@') === -1) { # Original message does not have @
+      # be strict and dont allow spaces when there wasnt an @ sign
+      return if response.match[1].trim().split(' ').length > 1
+      targetToken = response.match[1].trim()
+    } else { # Original message has @
+      # be a little less strict and dont allow more than one space when there was an @ sign
+      return if response.match[1].replace(/.*@/, '').trim().split(' ').length > 2
+      targetToken = response.match[1].replace(/.*@/, '').trim()
+    }
     return if not targetToken
+
     targetUser = userForToken targetToken, response
     return if not targetUser
     return response.send "Hey, you can't give yourself karma!" if thisUser is targetUser

--- a/scripts/karma.coffee
+++ b/scripts/karma.coffee
@@ -15,12 +15,14 @@ module.exports = (robot) ->
 
     if (response.match[0].indexOf('@') === -1) { # Original message does not have @
       # be strict and dont allow spaces when there wasnt an @ sign
-      return if response.match[1].trim().split(' ').length > 1
-      targetToken = response.match[1].trim()
+      possibleToken = response.match[1].trim()
+      return if possibleToken.split(' ').length > 1
+      targetToken = possibleToken
     } else { # Original message has @
       # be a little less strict and dont allow more than one space when there was an @ sign
-      return if response.match[1].replace(/.*@/, '').trim().split(' ').length > 2
-      targetToken = response.match[1].replace(/.*@/, '').trim()
+      possibleToken = response.match[1].replace(/.*@/, '').trim()
+      return if possibleToken.split(' ').length > 2
+      targetToken = possibleToken
     }
     return if not targetToken
 

--- a/scripts/karma.coffee
+++ b/scripts/karma.coffee
@@ -13,17 +13,17 @@ module.exports = (robot) ->
   robot.hear /^@?(.*?)(\+\+|--).*?$/, (response) ->
     thisUser = response.message.user
 
-    if (response.match[0].indexOf('@') === -1) { # Original message does not have @
-      # be strict and dont allow spaces when there wasnt an @ sign
+    if response.match[0].indexOf('@') === -1
+      # be strict and dont allow spaces when there was no @ sign
       possibleToken = response.match[1].trim()
       return if possibleToken.split(' ').length > 1
       targetToken = possibleToken
-    } else { # Original message has @
+    else
       # be a little less strict and dont allow more than one space when there was an @ sign
       possibleToken = response.match[1].replace(/.*@/, '').trim()
       return if possibleToken.split(' ').length > 2
       targetToken = possibleToken
-    }
+
     return if not targetToken
 
     targetUser = userForToken targetToken, response


### PR DESCRIPTION
Try setting target token based on the original message having or not having an @ sign. 

```
if !@
  return if there was more than one word matched
  assign targetToken
else 
  return if there was more than 2 words matched
  assign targetToken
  
return if not targetToken
``` 

Testing the matching, trimming, and splitting with mocha/chai: https://codesandbox.io/s/mocha-chai-browser-test-forked-7imfe

Note: if you get an error when loading that codesandbox, hit the circle refresh icon in the preview area of the right side.

Branch ready to revert if it doesn't work: https://github.com/SparkPost/mbot/pull/new/revert-handle-at-sign-karmas-differently